### PR TITLE
change vivliostyle theme author to Vivliostyle (project team)

### DIFF
--- a/packages/@vivliostyle/theme-bunko/README.md
+++ b/packages/@vivliostyle/theme-bunko/README.md
@@ -28,4 +28,4 @@ module.exports = {
 
 CC0 1.0
 
-> Original author: Shinyu Murakami
+> Original author: Vivliostyle project team

--- a/packages/@vivliostyle/theme-bunko/package.json
+++ b/packages/@vivliostyle/theme-bunko/package.json
@@ -2,7 +2,7 @@
   "name": "@vivliostyle/theme-bunko",
   "description": "文庫用のテーマ",
   "version": "0.2.2",
-  "author": "Shinyu Murakami <murakami@vivliostyle.org>",
+  "author": "Vivliostyle <mail@vivliostyle.org>",
   "scripts": {
     "dev": "vivliostyle-theme-scripts preview theme.css --layout example/bunko.md"
   },

--- a/packages/@vivliostyle/theme-slide/README.md
+++ b/packages/@vivliostyle/theme-slide/README.md
@@ -28,4 +28,4 @@ module.exports = {
 
 CC0 1.0
 
-> Original author: Shinyu Murakami
+> Original author: Vivliostyle project team

--- a/packages/@vivliostyle/theme-slide/package.json
+++ b/packages/@vivliostyle/theme-slide/package.json
@@ -2,7 +2,7 @@
   "name": "@vivliostyle/theme-slide",
   "description": "Slide theme",
   "version": "0.2.2",
-  "author": "Shinyu Murakami <murakami@vivliostyle.org>",
+  "author": "Vivliostyle <mail@vivliostyle.org>",
   "scripts": {
     "dev": "vivliostyle-theme-scripts preview theme.css --layout example/slide.md"
   },


### PR DESCRIPTION
bunkoとslideのthemeのauthorが私になっていましたが、私個人の作とはいえないものであるので、 author: Vivliostyle あるいは Vivliostyle project team としたほうが適切であると思います。