### PR TITLE
Include scss/ and example/ files to packages

### DIFF
--- a/packages/@vivliostyle/theme-academic/package.json
+++ b/packages/@vivliostyle/theme-academic/package.json
@@ -17,7 +17,9 @@
   },
   "files": [
     "*.css",
-    "*.css.map"
+    "*.css.map",
+    "scss",
+    "example"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/@vivliostyle/theme-bunko/package.json
+++ b/packages/@vivliostyle/theme-bunko/package.json
@@ -10,7 +10,8 @@
     "vivliostyle-theme-scripts": "^0.3.0"
   },
   "files": [
-    "*.css"
+    "*.css",
+    "example"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/@vivliostyle/theme-slide/package.json
+++ b/packages/@vivliostyle/theme-slide/package.json
@@ -10,7 +10,8 @@
     "vivliostyle-theme-scripts": "^0.3.0"
   },
   "files": [
-    "*.css"
+    "*.css",
+    "example"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/@vivliostyle/theme-techbook/package.json
+++ b/packages/@vivliostyle/theme-techbook/package.json
@@ -17,7 +17,9 @@
   },
   "files": [
     "*.css",
-    "*.css.map"
+    "*.css.map",
+    "scss",
+    "example"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/create-vivliostyle-theme/templates/default/package.json
+++ b/packages/create-vivliostyle-theme/templates/default/package.json
@@ -11,7 +11,10 @@
     "vivliostyle-theme-scripts": "^0.2.0"
   },
   "files": [
-    "*.css"
+    "*.css",
+    "*.css.map",
+    "scss",
+    "example"
   ],
   "keywords": [
     "vivliostyle",


### PR DESCRIPTION
> テーマのCSSのscssソースをカスタマイズに活かすことができるように、各themeのpackage.jsonの "files" にscssも含めるとよさそうですね
> それからテーマのパッケージに入っている example もここに含めるとよさそうです。そうすると create-book でこのexampleもインストールできるようになり、それを参考に原稿作成したり、スタイルのカスタマイズのためにも有用でしょう。
> https://github.com/vivliostyle/themes/issues/9#issuecomment-673290714

- 既存パッケージの次のバージョンからとscssとexampleディレクトリもパッケージに含まれるようにした
- create-vivliostyle-theme の package.json テンプレートを修正し、scssとexampleディレクトリがデフォルトでパッケージに含まれるようにした