### PR TITLE
WAI-ARIA role syntax for VFM has been removed since it was postponed in v1.0

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -136,68 +136,6 @@ body: {
 }
 ```
 
-### `role` first, then custom classes
-
-Take advantage of Digital Publishing WAI-ARIA `role` based blocks.
-If these roles would not satisfy your use cases, now then consider using custom classes. Keep in mind that the users have to stick with your theme manual and memorize the list of class names available in your theme, which produces extra learning cost.
-
-See [VFM `role` syntax](https://vivliostyle.github.io/vfm/#/vfm#wai-aria-role) to understand how VFM treats these elements.
-
-#### Example usage
-
-```css
-[role='doc-appendix'] {
-  padding: 15px;
-  background: yellow;
-}
-
-[role='doc-glossary'] {
-  font-family: monospace;
-}
-```
-
-#### Available roles
-
-- `doc-abstract` (Abstract; 概要)
-- `doc-acknowledgements` (Acknowledgements; 免責事項)
-- `doc-afterword`
-- `doc-appendix` (Appendix; 補遺)
-- `doc-backlink` (Back link)
-- `doc-biblioentry`
-- `doc-bibliography`
-- `doc-biblioref`
-- `doc-chapter` (Chapter; 章)
-- `doc-colophon` (Colophon; 奥付)
-- `doc-conclusion` (Conclusion; 総括)
-- `doc-cover` (Cover; 表紙)
-- `doc-credit` (Credit list item)
-- `doc-credits` (Credits)
-- `doc-dedication`
-- `doc-endnote`
-- `doc-endnotes`
-- `doc-epigraph`
-- `doc-epilogue` (Epilogue; 結文)
-- `doc-errata` (Errata; 正誤表)
-- `doc-example` (Example; 例)
-- `doc-footnote` (Foot note; フットノート)
-- `doc-foreword`
-- `doc-glossary` (Glossary; 用語集)
-- `doc-glossref`
-- `doc-index`
-- `doc-introduction` (Introductory section; はじめに)
-- `doc-noteref`
-- `doc-notice` (Notice; 注意)
-- `doc-pagebreak`
-- `doc-pagelist`
-- `doc-part`
-- `doc-preface` (Preface; まえがき)
-- `doc-prologue` (Prologue; 序文)
-- `doc-pullquote`
-- `doc-qna` (Q&A)
-- `doc-subtitle` (Sub title; サブタイトル)
-- `doc-tip` (Tips)
-- `doc-toc` (Table of Contents; 目次)
-
 ### `<figure>` for captioned image
 
 ```css


### PR DESCRIPTION
以下のように VFM v1.0 では WAI-ARIA role 構文を見送りとしたので themes の該当記述を削除しました。

- [#67 Remove Fenced block and WAI-ARIA role from v1.0 by akabekobeko · Pull Request #68 · vivliostyle/vfm](https://github.com/vivliostyle/vfm/pull/68)

@MurakamiShinyu @yamasy1549 
確認のうえ、問題なければ merge をお願いします。