### PR TITLE
Update create-vivliostyle-theme

### DIFF
--- a/packages/create-vivliostyle-theme/package.json
+++ b/packages/create-vivliostyle-theme/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.0",
-    "create-create-app": "^5.6.1"
+    "create-create-app": "^7.0.2"
   },
   "devDependencies": {
     "shx": "^0.3.2",

--- a/packages/create-vivliostyle-theme/src/cli.ts
+++ b/packages/create-vivliostyle-theme/src/cli.ts
@@ -22,5 +22,5 @@ create('create-vivliostyle-theme', {
     },
   },
   caveat,
-  handleName: (name) => `vivliostyle-theme-${name}`,
+  modifyName: (name) => `vivliostyle-theme-${name}`,
 });

--- a/packages/create-vivliostyle-theme/src/cli.ts
+++ b/packages/create-vivliostyle-theme/src/cli.ts
@@ -8,7 +8,7 @@ const templateRoot = resolve(__dirname, '../templates');
 
 const caveat = ({ name }: AfterHookOptions) => `
 ${chalk.gray('1.')} cd ${chalk.bold.green(name)}
-${chalk.gray('2.')} edit ${chalk.bold.green('theme.css')}
+${chalk.gray('2.')} edit ${chalk.bold.green('scss/*.scss')}
 ${chalk.gray('3.')} publish to npm (${chalk.cyan('$ npm publish')})
 `;
 

--- a/packages/create-vivliostyle-theme/templates/default/README.md
+++ b/packages/create-vivliostyle-theme/templates/default/README.md
@@ -26,20 +26,64 @@ module.exports = {
 
 ## Dev
 
-Run `vivliostyle-theme-scripts preview` to preview your `theme.css`.
+### Files
 
-```bash
-vivliostyle-theme-scripts preview theme.css
+```
+{{kebab name}}
+├── LICENSE
+├── README.md
+├── example
+│   ├── default.html       // auto generated
+│   └── default.md         // 🖋
+├── package.json
+├── scss                   // 🖋
+│   ├── theme_common.scss
+│   ├── theme_print.scss
+│   └── theme_screen.scss
+├── theme_common.css       // auto generated
+├── theme_common.css.map   // auto generated
+├── theme_print.css        // auto generated
+├── theme_print.css.map    // auto generated
+├── theme_screen.css       // auto generated
+├── theme_screen.css.map   // auto generated
+└── vivliostyle.config.js
 ```
 
-You can specify layout file with `--layout` flag:
+**example**: Contain sample manuscripts using your theme.
+
+**scss**: You can add files for specific use (print, screen, cover, toc, preface, ...) and apply them at `theme` `entry > theme` in vivliostyle.config.js. Partial files whose names begin with `_` will be ignored.
+
+
+### Commands
+
+Run `vivliostyle preview` to preview your `theme_*.css`.
+
+To watch file changes, use `dev` script.
 
 ```bash
-vivliostyle-theme-scripts preview theme.css --layout example/default.md
+npm run dev
+# or
+yarn dev
+```
+
+You can specify your CSS file and manuscript file for preview in vivliostyle.config.js:
+
+```js
+module.exports = {
+  language: 'en',
+  theme: 'theme_print.css',
+  // theme: 'theme_screen.css',
+  entry: [
+      'example/default.md',
+      // and more...
+  ],
+}
 ```
 
 Run `vivliostyle-theme-scripts validate` before publishing your package.
 
 ```bash
-vivliostyle-theme-scripts validate
+npm run validate
+# or
+yarn validate
 ```

--- a/packages/create-vivliostyle-theme/templates/default/package.json
+++ b/packages/create-vivliostyle-theme/templates/default/package.json
@@ -8,7 +8,7 @@
     "validate": "vivliostyle-theme-scripts validate"
   },
   "devDependencies": {
-    "vivliostyle-theme-scripts": "^0.2.0"
+    "vivliostyle-theme-scripts": "^0.3.1"
   },
   "files": [
     "*.css",

--- a/packages/create-vivliostyle-theme/templates/default/package.json
+++ b/packages/create-vivliostyle-theme/templates/default/package.json
@@ -4,10 +4,16 @@
   "version": "0.1.0",
   "author": "{{contact}}",
   "scripts": {
-    "dev": "vivliostyle-theme-scripts preview theme.css",
-    "validate": "vivliostyle-theme-scripts validate"
+    "build": "run-p build:scss",
+    "build:scss": "sass scss:.",
+    "dev": "run-p preview watch:scss",
+    "preview": "vivliostyle-theme-scripts preview theme_print.css --layout example/default.md",
+    "validate": "vivliostyle-theme-scripts validate",
+    "watch:scss": "sass --watch scss:."
   },
   "devDependencies": {
+    "sass": "^1.32.8",
+    "npm-run-all": "^4.1.5",
     "vivliostyle-theme-scripts": "^0.3.1"
   },
   "files": [

--- a/packages/create-vivliostyle-theme/templates/default/package.json
+++ b/packages/create-vivliostyle-theme/templates/default/package.json
@@ -33,7 +33,7 @@
     "theme": {
       "name": "{{capital name space=true}}",
       "author": "{{contact}}",
-      "style": "./theme.css",
+      "style": "./theme_print.css",
       "category": "{{category}}",
       "topics": []
     }

--- a/packages/create-vivliostyle-theme/templates/default/package.json
+++ b/packages/create-vivliostyle-theme/templates/default/package.json
@@ -7,11 +7,12 @@
     "build": "run-p build:scss",
     "build:scss": "sass scss:.",
     "dev": "run-p preview watch:scss",
-    "preview": "vivliostyle-theme-scripts preview theme_print.css --layout example/default.md",
+    "preview": "vivliostyle preview",
     "validate": "vivliostyle-theme-scripts validate",
     "watch:scss": "sass --watch scss:."
   },
   "devDependencies": {
+    "@vivliostyle/cli": "^3.2.1",
     "sass": "^1.32.8",
     "npm-run-all": "^4.1.5",
     "vivliostyle-theme-scripts": "^0.3.1"

--- a/packages/create-vivliostyle-theme/templates/default/package.json
+++ b/packages/create-vivliostyle-theme/templates/default/package.json
@@ -21,7 +21,8 @@
     "*.css",
     "*.css.map",
     "scss",
-    "example"
+    "example",
+    "vivliostyle.config.js"
   ],
   "keywords": [
     "vivliostyle",

--- a/packages/create-vivliostyle-theme/templates/default/package.json
+++ b/packages/create-vivliostyle-theme/templates/default/package.json
@@ -12,7 +12,7 @@
     "watch:scss": "sass --watch scss:."
   },
   "devDependencies": {
-    "@vivliostyle/cli": "^3.2.1",
+    "@vivliostyle/cli": "^3.3.0",
     "sass": "^1.32.8",
     "npm-run-all": "^4.1.5",
     "vivliostyle-theme-scripts": "^0.3.1"

--- a/packages/create-vivliostyle-theme/templates/default/scss/theme_common.scss
+++ b/packages/create-vivliostyle-theme/templates/default/scss/theme_common.scss
@@ -2,23 +2,27 @@
  * For all media (print, screen)
  */
 
+/* you can import partial SCSS files */
+/* @import '_valiables'; */
+/* @import '_toc'; */
+/* ... */
+
 html {
   orphans: 1;
   widows: 1;
-}
-
-* {
-  margin: 0;
-  padding: 0;
 }
 
 @page {
   size: A5;
 }
 
+title {
+  string-set: doc-title content();
+}
+
 @page :left {
   @top-left {
-    content: counter(page) '　' env(doc-title);
+    content: counter(page) '　' string(doc-title);
   }
 }
 
@@ -41,11 +45,6 @@ h2 {
   font-size: 1.18rem;
   text-indent: 3rem;
   break-after: avoid;
-}
-
-[role='doc-appendix'] {
-  margin-block-start: 6rem;
-  break-inside: avoid;
 }
 
 /* and more... 🖋 */

--- a/packages/create-vivliostyle-theme/templates/default/scss/theme_common.scss
+++ b/packages/create-vivliostyle-theme/templates/default/scss/theme_common.scss
@@ -1,8 +1,3 @@
-/*
- * {{capital name space=true}}
- * author: {{contact}}
- */
-
 html {
   orphans: 1;
   widows: 1;

--- a/packages/create-vivliostyle-theme/templates/default/scss/theme_common.scss
+++ b/packages/create-vivliostyle-theme/templates/default/scss/theme_common.scss
@@ -1,3 +1,7 @@
+/*
+ * For all media (print, screen)
+ */
+
 html {
   orphans: 1;
   widows: 1;
@@ -9,9 +13,7 @@ html {
 }
 
 @page {
-  size: 148mm 210mm;
-  width: 360pt;
-  height: 468pt;
+  size: A5;
 }
 
 @page :left {
@@ -45,3 +47,5 @@ h2 {
   margin-block-start: 6rem;
   break-inside: avoid;
 }
+
+/* and more... 🖋 */

--- a/packages/create-vivliostyle-theme/templates/default/scss/theme_print.scss
+++ b/packages/create-vivliostyle-theme/templates/default/scss/theme_print.scss
@@ -11,7 +11,7 @@
   marks: crop cross;
   bleed: 3mm;
 
-  /* if you open the manuscripts on Vivliostyle Viewer, this message will be shown */
+  /* if you open the publications on Vivliostyle Viewer, this message will be shown */
   @top-left {
     content: 'theme_print';
   }

--- a/packages/create-vivliostyle-theme/templates/default/scss/theme_print.scss
+++ b/packages/create-vivliostyle-theme/templates/default/scss/theme_print.scss
@@ -11,7 +11,7 @@
   marks: crop cross;
   bleed: 3mm;
 
-  /* if you open the publications on Vivliostyle Viewer, this message will be shown */
+  /* if you open the publication on Vivliostyle Viewer, this message will be shown */
   @top-left {
     content: 'theme_print';
   }

--- a/packages/create-vivliostyle-theme/templates/default/scss/theme_print.scss
+++ b/packages/create-vivliostyle-theme/templates/default/scss/theme_print.scss
@@ -1,0 +1,11 @@
+@import 'theme_common';
+
+@page {
+  size: A5;
+  marks: crop cross;
+  bleed: 3mm;
+
+  @top-left {
+    content: 'For print';
+  }
+}

--- a/packages/create-vivliostyle-theme/templates/default/scss/theme_print.scss
+++ b/packages/create-vivliostyle-theme/templates/default/scss/theme_print.scss
@@ -1,11 +1,20 @@
+/*
+ * For PDF publications or Vivliostyle Viewer:
+ * load this style in PDF publicatoins (format: pdf)
+ */
+
+/* common styles */
 @import 'theme_common';
 
 @page {
-  size: A5;
+  /* show bleeds */
   marks: crop cross;
   bleed: 3mm;
 
+  /* if you open the manuscripts on Vivliostyle Viewer, this message will be shown */
   @top-left {
-    content: 'For print';
+    content: 'theme_print';
   }
 }
+
+/* and more... 🖋 */

--- a/packages/create-vivliostyle-theme/templates/default/scss/theme_screen.scss
+++ b/packages/create-vivliostyle-theme/templates/default/scss/theme_screen.scss
@@ -7,7 +7,7 @@
 @import 'theme_common';
 
 @page {
-  /* if you open the publicatoins on Vivliostyle Viewer, this message will be shown */
+  /* if you open the publication on Vivliostyle Viewer, this message will be shown */
   @top-left {
     content: 'theme_screen';
   }

--- a/packages/create-vivliostyle-theme/templates/default/scss/theme_screen.scss
+++ b/packages/create-vivliostyle-theme/templates/default/scss/theme_screen.scss
@@ -7,7 +7,7 @@
 @import 'theme_common';
 
 @page {
-  /* if you open the manuscripts on Vivliostyle Viewer, this message will be shown */
+  /* if you open the publicatoins on Vivliostyle Viewer, this message will be shown */
   @top-left {
     content: 'theme_screen';
   }
@@ -16,7 +16,7 @@
 /* for wide screen */
 body {
   max-width: 800px;
-  margin: auto 2rem 2rem;
+  margin: 2rem auto 2rem;
 }
 
 /* highlight footnote */

--- a/packages/create-vivliostyle-theme/templates/default/scss/theme_screen.scss
+++ b/packages/create-vivliostyle-theme/templates/default/scss/theme_screen.scss
@@ -1,9 +1,33 @@
+/*
+ * For browser viewing:
+ * load this style in Web publications (format: webpub)
+ */
+
+/* common styles */
 @import 'theme_common';
 
 @page {
-  width: 800px;
-
+  /* if you open the manuscripts on Vivliostyle Viewer, this message will be shown */
   @top-left {
-    content: 'For screen';
+    content: 'theme_screen';
   }
 }
+
+/* for wide screen */
+body {
+  max-width: 800px;
+  margin: auto 2rem 2rem;
+}
+
+/* highlight footnote */
+.footnote {
+  vertical-align: super;
+  background-color: aliceblue;
+  color: gray;
+
+  a {
+    word-break: break-all;
+  }
+}
+
+/* and more... 🖋 */

--- a/packages/create-vivliostyle-theme/templates/default/scss/theme_screen.scss
+++ b/packages/create-vivliostyle-theme/templates/default/scss/theme_screen.scss
@@ -1,0 +1,9 @@
+@import 'theme_common';
+
+@page {
+  width: 800px;
+
+  @top-left {
+    content: 'For screen';
+  }
+}

--- a/packages/create-vivliostyle-theme/templates/default/vivliostyle.config.js
+++ b/packages/create-vivliostyle-theme/templates/default/vivliostyle.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  language: 'en',
+  theme: 'theme_print.css',
+  entry: [
+    'example/default.md',
+  ],
+}


### PR DESCRIPTION
作られる雛形の構造が少し変わるので、バージョンは 0.2.0 -> 0.3.0 にしようと思います

## #30 create-vivliostyle-theme で作った theme の確認時にオートリロードしてほしい
- 原稿・スタイルのプレビューに vivliostyle-cli を使うようにした

## #25 theme package に複数のスタイルシートを含める
- theme_{common, print, screen}.css をデフォルトで用意した
- create-vivliostyle-theme で theme の雛形を作った際、すぐに SCSS が使えるようにした（これまでは optional だった）