### PR TITLE
repositoryプロパティを追加

### DIFF
--- a/packages/@vivliostyle/theme-gutenberg/package.json
+++ b/packages/@vivliostyle/theme-gutenberg/package.json
@@ -38,5 +38,10 @@
       "category": "novel",
       "topics": []
     }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vivliostyle/themes.git",
+    "directory": "packages/@vivliostyle/theme-gutenberg"
   }
 }


### PR DESCRIPTION
repositoryプロパティが無いとnpmの検索結果からGitHubのリポジトリを探せないので追加をお願い致します。