### PR TITLE
Add "config" to "files" of theme-gutenberg/package.json

### DIFF
--- a/packages/@vivliostyle/theme-gutenberg/package.json
+++ b/packages/@vivliostyle/theme-gutenberg/package.json
@@ -23,6 +23,7 @@
     "*.css.map",
     "scss",
     "example",
+    "config",
     "vivliostyle.config.js"
   ],
   "keywords": [


### PR DESCRIPTION
theme-gutenberg の vivliostyle.config.js の内容は './config/alice/vivliostyle.config.js' を取り込むようになっています：

```js
const config = require('./config/alice/vivliostyle.config.js');

module.exports = config;
```

しかし、theme-gutenberg の package.json の "files" に "config" がないために、"config" ディレクトリがコピーされないため、 ` require('./config/alice/vivliostyle.config.js');` でエラーになります。

そこで package.json の "files" に "config" を追加しました。
