### PR TITLE
fix: delete duplicate css variable

### DIFF
--- a/packages/@vivliostyle/theme-base/css/lib/prism/theme-okaidia.css
+++ b/packages/@vivliostyle/theme-base/css/lib/prism/theme-okaidia.css
@@ -30,7 +30,6 @@
   --vs-prism--color-operator: #f8f8f2;
   --vs-prism--color-entity: #f8f8f2;
   --vs-prism--color-url: #f8f8f2;
-  --vs-prism--color-string: #f8f8f2;
   --vs-prism--color-variable: #f8f8f2;
 
   --vs-prism--color-atrule: #e6db74;

--- a/packages/@vivliostyle/theme-base/css/lib/prism/theme-prism.css
+++ b/packages/@vivliostyle/theme-base/css/lib/prism/theme-prism.css
@@ -29,7 +29,6 @@
   --vs-prism--color-operator: #9a6e3a;
   --vs-prism--color-entity: #9a6e3a;
   --vs-prism--color-url: #9a6e3a;
-  --vs-prism--color-string: #9a6e3a;
 
   --vs-prism--color-atrule: #07a;
   --vs-prism--color-attr-value: #07a;


### PR DESCRIPTION
以下のCSSで `--vs-prism--color-string` 変数が重複していました。
- theme-okaidia.css
- theme-prism.css

[Prism.js](https://prismjs.com/) の色定義に沿うように、不要な変数を削除しました。