### PR TITLE
update-readme-of-create-vivliostyle-theme-template

### DIFF
--- a/packages/create-vivliostyle-theme/templates/default/README.md
+++ b/packages/create-vivliostyle-theme/templates/default/README.md
@@ -25,28 +25,26 @@ module.exports = {
 ├── LICENSE
 ├── README.md
 ├── example
-│   ├── default.html       // auto generated
-│   └── default.md         // 🖋
+│   ├── assets                            // auto generated
+│        ├── Logo (Mark + Type).png       // auto generated
+│   └── default.md                        // 🖋
 ├── package.json
-├── theme.css              // 🖋
+├── theme.css                             // 🖋
 └── vivliostyle.config.js
 ```
 
 **example**: Contain sample manuscripts using your theme.
 
-**scss**: You can add files for specific use (print, screen, cover, toc, preface, ...) and apply them at `theme` `entry > theme` in vivliostyle.config.js. Partial files whose names begin with `_` will be ignored.
-
-
 ### Commands
 
-Run `vivliostyle preview` to preview your `theme_*.css`.
+Run `vivliostyle preview` to preview your `theme.css`.
 
-To watch file changes, use `dev` script.
+To watch file changes, use `preview` script.
 
 ```bash
-npm run dev
+npm run preview
 # or
-yarn dev
+yarn preview
 ```
 
 You can specify your CSS file and manuscript file for preview in vivliostyle.config.js:

--- a/packages/create-vivliostyle-theme/templates/default/README.md
+++ b/packages/create-vivliostyle-theme/templates/default/README.md
@@ -16,6 +16,17 @@ module.exports = {
 };
 ```
 
+If you want to add your CSS:
+
+```js
+module.exports = {
+  theme: [
+    '{{kebab name}}',
+    // add your CSS 
+  ],
+};
+```
+
 ## Dev
 
 ### Files

--- a/packages/create-vivliostyle-theme/templates/default/README.md
+++ b/packages/create-vivliostyle-theme/templates/default/README.md
@@ -26,7 +26,7 @@ module.exports = {
 ├── README.md
 ├── example
 │   ├── assets                            // auto generated
-│        ├── Logo (Mark + Type).png       // auto generated
+│   │   └── Logo (Mark + Type).png        // auto generated
 │   └── default.md                        // 🖋
 ├── package.json
 ├── theme.css                             // 🖋


### PR DESCRIPTION
## やったこと
`$ npm create vivliostyle-theme <your-theme-name>` を実行した際に生成されるREADMEの内容と、生成されるThemeテンプレートとの内容に差異があったので、READMEの記述を修正しました。

## 修正のサマリ
- SCSS版の記載が残っていたので削除した
- `dev` は npm-scripts から削除されているので、`preview` に書き換えた
- 生成されるファイルが異なっているので、ファイルツリー表記を修正した