### PR TITLE
fix: Add a `main` property for package.json

### DIFF
--- a/.changeset/serious-pens-grab.md
+++ b/.changeset/serious-pens-grab.md
@@ -1,0 +1,13 @@
+---
+'@vivliostyle/theme-gutenberg': patch
+'@vivliostyle/theme-academic': patch
+'@vivliostyle/theme-techbook': patch
+'@vivliostyle/theme-epub3j': patch
+'@vivliostyle/theme-bunko': patch
+'@vivliostyle/theme-slide': patch
+'create-vivliostyle-theme': patch
+'@vivliostyle/theme-base': patch
+---
+
+Add a `main` property for package.json.
+This is useful for use with third-party libraries that are expected to have a `main` field in package.json.

--- a/packages/@vivliostyle/theme-academic/package.json
+++ b/packages/@vivliostyle/theme-academic/package.json
@@ -3,6 +3,7 @@
   "description": "Academic theme",
   "version": "1.0.0",
   "author": "Vivliostyle <mail@vivliostyle.org>",
+  "main": "theme.css",
   "scripts": {
     "build": "vivliostyle build",
     "preview": "vivliostyle preview",
@@ -46,7 +47,7 @@
     "theme": {
       "name": "Academic",
       "category": "academic",
-      "style": "./theme.css",
+      "style": "theme.css",
       "topics": [
         "Academic",
         "Report"

--- a/packages/@vivliostyle/theme-base/package.json
+++ b/packages/@vivliostyle/theme-base/package.json
@@ -3,6 +3,7 @@
   "description": "Base theme and CSS toolkit for Vivliostyle themes",
   "version": "1.0.0",
   "author": "Vivliostyle <mail@vivliostyle.org>",
+  "main": "theme-all.css",
   "scripts": {
     "build": "vivliostyle build",
     "preview": "vivliostyle preview",
@@ -44,7 +45,7 @@
     "theme": {
       "name": "Vivliostyle Base Theme",
       "author": "Vivliostyle <mail@vivliostyle.org>",
-      "style": "./theme-all.css",
+      "style": "theme-all.css",
       "category": "misc",
       "topics": []
     }

--- a/packages/@vivliostyle/theme-bunko/package.json
+++ b/packages/@vivliostyle/theme-bunko/package.json
@@ -3,6 +3,7 @@
   "description": "文庫用のテーマ",
   "version": "1.0.0",
   "author": "Vivliostyle <mail@vivliostyle.org>",
+  "main": "theme.css",
   "scripts": {
     "build": "vivliostyle build",
     "preview": "vivliostyle preview",
@@ -45,7 +46,7 @@
   "vivliostyle": {
     "theme": {
       "name": "Bunko",
-      "style": "./theme.css",
+      "style": "theme.css",
       "category": "novel",
       "topics": [
         "小説",

--- a/packages/@vivliostyle/theme-epub3j/package.json
+++ b/packages/@vivliostyle/theme-epub3j/package.json
@@ -3,6 +3,7 @@
   "description": "EPUB3 (Japanese) 日本語EPUB用テーマ（電書協EPUB3制作ガイド準拠）",
   "version": "1.0.0",
   "author": "Vivliostyle <mail@vivliostyle.org>",
+  "main": "theme.css",
   "scripts": {
     "build": "vivliostyle build",
     "preview": "vivliostyle preview",
@@ -43,7 +44,7 @@
   "vivliostyle": {
     "theme": {
       "name": "EPUB3 (Japanese)",
-      "style": "./theme.css",
+      "style": "theme.css",
       "category": "misc",
       "topics": []
     }

--- a/packages/@vivliostyle/theme-gutenberg/package.json
+++ b/packages/@vivliostyle/theme-gutenberg/package.json
@@ -3,6 +3,7 @@
   "description": "Book theme for latin font",
   "version": "1.0.0",
   "author": "Vivliostyle <mail@vivliostyle.org>",
+  "main": "theme.css",
   "scripts": {
     "build": "vivliostyle build",
     "preview": "vivliostyle preview",
@@ -38,7 +39,7 @@
     "theme": {
       "name": "Gutenberg",
       "author": "Vivliostyle <mail@vivliostyle.org>",
-      "style": "./theme.css",
+      "style": "theme.css",
       "category": "novel",
       "topics": []
     }

--- a/packages/@vivliostyle/theme-slide/package.json
+++ b/packages/@vivliostyle/theme-slide/package.json
@@ -3,6 +3,7 @@
   "description": "Slide theme",
   "version": "1.0.0",
   "author": "Vivliostyle <mail@vivliostyle.org>",
+  "main": "theme.css",
   "scripts": {
     "build": "vivliostyle build",
     "preview": "vivliostyle preview",
@@ -46,7 +47,7 @@
     "theme": {
       "name": "Slide",
       "category": "misc",
-      "style": "./theme.css",
+      "style": "theme.css",
       "topics": [
         "Slide"
       ]

--- a/packages/@vivliostyle/theme-techbook/package.json
+++ b/packages/@vivliostyle/theme-techbook/package.json
@@ -3,6 +3,7 @@
   "description": "Techbook (技術同人誌) theme",
   "version": "1.0.0",
   "author": "Vivliostyle <mail@vivliostyle.org>",
+  "main": "theme.css",
   "scripts": {
     "build": "vivliostyle build",
     "preview": "vivliostyle preview",
@@ -46,7 +47,7 @@
     "theme": {
       "name": "Techbook",
       "category": "misc",
-      "style": "./theme.css",
+      "style": "theme.css",
       "topics": [
         "Techbook"
       ]

--- a/packages/create-vivliostyle-theme/templates/default/package.json
+++ b/packages/create-vivliostyle-theme/templates/default/package.json
@@ -3,6 +3,7 @@
   "description": "{{description}}",
   "version": "0.1.0",
   "author": "{{contact}}",
+  "main": "theme.css",
   "scripts": {
     "build": "vivliostyle build",
     "preview": "vivliostyle preview",
@@ -37,7 +38,7 @@
     "theme": {
       "name": "{{capital name space=true}}",
       "author": "{{contact}}",
-      "style": "./theme.css",
+      "style": "theme.css",
       "category": "{{category}}",
       "topics": []
     }


### PR DESCRIPTION
I confirmed that it is a requirement that the `main` field be set in package.json in some environments. For example, esm.sh and Unpkg allow us to get the URLs by specifying the package name, but this requires specifying the CSS file what we want to load in the `main` field.

### Currently available URLs

* https://unpkg.com/@vivliostyle/theme-bunko/theme.css
* https://esm.sh/@vivliostyle/theme-bunko/theme.css

### URLs available by setting the `main` field

* https://unpkg.com/@vivliostyle/theme-bunko
* https://esm.sh/@vivliostyle/theme-bunko
