### PR TITLE
fix: Doc counter

### DIFF
--- a/.changeset/clean-socks-think.md
+++ b/.changeset/clean-socks-think.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/theme-base": patch
+---
+
+Fix cases where both the chapter and part page counters are set

--- a/.changeset/hip-parrots-rush.md
+++ b/.changeset/hip-parrots-rush.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/theme-base": patch
+---
+
+Don't increment `vs-counter-doc` for ToC/cover documents

--- a/.changeset/neat-windows-exist.md
+++ b/.changeset/neat-windows-exist.md
@@ -1,0 +1,11 @@
+---
+"@vivliostyle/theme-base": minor
+---
+
+Add variables to override the initial counter value at the document root.
+
+The following CSS variables are supported:
+
+- `--vs-crossref--root-counter-{fig|tbl|cite}`
+- `--vs-footnote--root-counter-footnote`
+- `--vs-section--root-counter-{sections|sec-h1|sec-h2|sec-h3|sec-h4|sec-h5|sec-h6}`

--- a/packages/@vivliostyle/theme-base/css/common/basic.css
+++ b/packages/@vivliostyle/theme-base/css/common/basic.css
@@ -178,6 +178,7 @@ html {
 body {
   counter-reset: var(--vs-crossref--root-counter-reset,)
     var(--vs-footnote--root-counter-reset,)
+    var(--vs-section--root-counter-reset,)
     var(--vs-document-root-counter-reset,);
 }
 

--- a/packages/@vivliostyle/theme-base/css/common/meta-properties.css
+++ b/packages/@vivliostyle/theme-base/css/common/meta-properties.css
@@ -68,4 +68,13 @@
    */
   --vs-document-root-counter-reset: ;
   --vs-first-page-counter-reset: ;
+
+  /**
+   * Counter increments
+   * It is used for incrementing CSS counters on a first page of a document
+   * Caution: Don't set counter-reset directly otherwise all other counters will be ignored.
+   * OK: :root { --vs-document-first-page-counter-increment: foo bar; }
+   * NG: @page :nth(1) { counter-increment: foo bar; }
+   */
+  --vs-document-first-page-counter-increment: ;
 }

--- a/packages/@vivliostyle/theme-base/css/partial/crossref.css
+++ b/packages/@vivliostyle/theme-base/css/partial/crossref.css
@@ -25,8 +25,10 @@
     counter(vs-counter-tbl, var(--vs-crossref--counter-style)) ': ';
   --vs-crossref--marker-cite-content: '[' counter(vs-counter-cite) ']';
   --vs-crossref--marker-margin-inline: 0;
-  --vs-crossref--root-counter-reset: vs-counter-fig vs-counter-tbl
-    vs-counter-cite;
+  --vs-crossref--root-counter-reset: vs-counter-fig
+    var(--vs-crossref--root-counter-fig,) vs-counter-tbl
+    var(--vs-crossref--root-counter-tbl,) vs-counter-cite
+    var(--vs-crossref--root-counter-cite,);
 
   /* displays dummy content on screen media that doesn't support target-counter() */
   --vs-crossref--call-fig-content-on-screen: 'Figure ???';

--- a/packages/@vivliostyle/theme-base/css/partial/footnote.css
+++ b/packages/@vivliostyle/theme-base/css/partial/footnote.css
@@ -17,7 +17,8 @@
   --vs-footnote--area-before-margin-inline: var(--vs--hr-margin-inline);
   --vs-footnote--item-margin-block: 0;
   --vs-footnote--item-margin-inline: 0;
-  --vs-footnote--root-counter-reset: vs-counter-footnote;
+  --vs-footnote--root-counter-reset: vs-counter-footnote
+    var(--vs-footnote--root-counter-footnote,);
 }
 
 .footnote,

--- a/packages/@vivliostyle/theme-base/css/partial/page.css
+++ b/packages/@vivliostyle/theme-base/css/partial/page.css
@@ -426,22 +426,37 @@
  * document counters
  */
 
+html.chapter,
+body.chapter {
+  page: chapter-document;
+}
+
 html.part,
-body.part,
-[role='doc-part'] {
-  page: part;
+body.part {
+  page: part-document;
+}
+
+html.part.chapter,
+body.part.chapter {
+  page: part-chapter-document;
 }
 
 @page :nth(1) {
-  counter-increment: vs-counter-doc;
+  counter-increment: var(--vs-page--doc-counter-increment, vs-counter-doc)
+    var(--vs-document-first-page-counter-increment,);
 }
 
-@page part:nth(1) {
-  counter-increment: vs-counter-doc vs-counter-part;
+@page chapter-document {
+  --vs-page--doc-counter-increment: vs-counter-doc vs-counter-chapter;
 }
 
-@page chapter:nth(1) {
-  counter-increment: vs-counter-doc vs-counter-chapter;
+@page part-document {
+  --vs-page--doc-counter-increment: vs-counter-doc vs-counter-part;
+}
+
+@page part-chapter-document {
+  --vs-page--doc-counter-increment: vs-counter-doc vs-counter-part
+    vs-counter-chapter;
 }
 
 /*
@@ -487,12 +502,6 @@ html.bibliography,
 body.bibliography,
 [role='doc-bibliography'] {
   page: bibliography;
-}
-
-html.chapter,
-body.chapter,
-[role='doc-chapter'] {
-  page: chapter;
 }
 
 html.conclusion,

--- a/packages/@vivliostyle/theme-base/css/partial/page.css
+++ b/packages/@vivliostyle/theme-base/css/partial/page.css
@@ -441,6 +441,14 @@ body.part.chapter {
   page: part-chapter-document;
 }
 
+body:has([role='doc-toc']) {
+  page: toc-document;
+}
+
+body:has([role='doc-cover']) {
+  page: cover-document;
+}
+
 @page :nth(1) {
   counter-increment: var(--vs-page--doc-counter-increment, vs-counter-doc)
     var(--vs-document-first-page-counter-increment,);
@@ -457,6 +465,16 @@ body.part.chapter {
 @page part-chapter-document {
   --vs-page--doc-counter-increment: vs-counter-doc vs-counter-part
     vs-counter-chapter;
+}
+
+@page toc-document {
+  /* Don't increment vs-counter-doc for ToC documents */
+  --vs-page--doc-counter-increment: vs-counter-doc 0;
+}
+
+@page cover-document {
+  /* Don't increment vs-counter-doc for cover documents */
+  --vs-page--doc-counter-increment: vs-counter-doc 0;
 }
 
 /*

--- a/packages/@vivliostyle/theme-base/css/partial/section.css
+++ b/packages/@vivliostyle/theme-base/css/partial/section.css
@@ -19,6 +19,14 @@
     var(--vs-section--counter-style)
   );
   --vs-section--marker-margin-inline: 1ch;
+  --vs-section--root-counter-reset: vs-counter-sections
+    var(--vs-section--root-counter-sections,) vs-counter-sec-h1
+    var(--vs-section--root-counter-sec-h1,) vs-counter-sec-h2
+    var(--vs-section--root-counter-sec-h2,) vs-counter-sec-h3
+    var(--vs-section--root-counter-sec-h3,) vs-counter-sec-h4
+    var(--vs-section--root-counter-sec-h4,) vs-counter-sec-h5
+    var(--vs-section--root-counter-sec-h5,) vs-counter-sec-h6
+    var(--vs-section--root-counter-sec-h6,);
 }
 
 :lang(ja) {


### PR DESCRIPTION
#129

* Fix cases where both the chapter and part page counters are set
* Don't increment `vs-counter-doc` for ToC/cover documents
* Add variables to override the initial counter value at the document root

---

* 1つのドキュメントに `part` と `chapter` 両方のクラスが指定されていたときに `vs-counter-part` のカウンターがインクリメントされない問題を修正します
* ドキュメント内に `[role='doc-toc']` や `[role='doc-cover']` が含まれていたときに `vs-counter-doc` をインクリメントしないようにします。これにより、目次ページやカバーページが章としてカウントされないように修正します
* CSSカウンターの初期値をドキュメントルートで上書きするCSS変数を追加しました