### PR TITLE
chore: fix docs/index.md markdown code

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,18 +4,9 @@
 
 Vivliostyle Theme is a style theme used for creating publications with Vivliostyle. With Vivliostyle Themes, you can effortlessly change the style of your publications.
 
-<nav role="doc-toc">
-<ul>
-<li>
-<a href="./spec.md">Spec of Vivliostyle Theme</a>
-</li>
-<li>
+- [Spec of Vivliostyle Theme](./spec.md)
 
-### Operational Guidelines
+- ### Operational Guidelines
 
-- [Adoption of the Official Theme](./official.md)
-- [Vivliostyle Themes Gallery](./gallery.md)
-
-</li>
-</ul>
-</nav>
+  - [Adoption of the Official Theme](./official.md)
+  - [Vivliostyle Themes Gallery](./gallery.md)

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -4,18 +4,9 @@
 
 Vivliostyle Theme は、Vivliostyle で出版物を作る際に使うスタイルテーマです。Vivliostyle Themes を使うことで簡単に出版物のスタイルを変更することができます。
 
-<nav role="doc-toc">
-<ul>
-<li>
-<a href="./spec.md">Vivliostyle Theme の仕様</a>
-</li>
-<li>
+- [Vivliostyle Theme の仕様](./spec.md)
 
-### 運用ガイドライン
+- ### 運用ガイドライン
 
-- [公式 Theme の採用](./official.md)
-- [Vivliostyle Themes ギャラリー](./gallery.md)
-
-</li>
-</ul>
-</nav>
+  - [公式 Theme の採用](./official.md)
+  - [Vivliostyle Themes ギャラリー](./gallery.md)


### PR DESCRIPTION
次の問題を修正します。

テーマのドキュメントのソース  
https://github.com/vivliostyle/themes/blob/main/docs/index.md  
からGitHub Pagesで生成されているページ  
https://vivliostyle.github.io/themes/  
を見ると、次の問題があります：

- "Spec of Vivliostyle Theme" のリンクをクリックすると、マークダウンのソースが表示される
  - 原因：マークダウン形式での.mdファイルへのリンクはHTMLに変換されたときに.htmlファイルへのリンクに変わるが、HTML形式でのリンクは.mdファイルへのリンクのままになるため
- `### Operational Guidelines` 以下マークダウンのソースが表示されてリンクが機能しない
  - 原因：GitHub PagesのデフォルトのマークダウンパーサーはKramdownであり、HTMLブロックの扱いがGFMとは違って、HTML要素内のマークダウンは処理されないため

----

ThemesのドキュメントのURLとして https://vivliostyle.github.io/themes/ は廃止予定かもしれませんが、まだ存在するし、このリポジトリのWebsiteもまだそれに設定されてます。そこにアクセスされたときに、壊れたページになっているのはまずいと思うのでとりあえずこの修正を提案します。

`<nav role="doc-toc">` は削除しましたが、もしそれを残す必要があれば、GitHub PagesでGFMが使われるように `markdown: GFM` と書いた `_config.yml` ファイルを追加するとよいかと思います。 

