### PR TITLE
feat(base): Support --vs-document-first-page-counter-reset variable

### DIFF
--- a/packages/@vivliostyle/theme-base/css/common/meta-properties.css
+++ b/packages/@vivliostyle/theme-base/css/common/meta-properties.css
@@ -61,33 +61,22 @@
 }
 
 /**
- * Counter resets
- * It is used for resetting CSS counters on a root element or a first page
- * Caution: Don't set counter-reset directly otherwise all other counters will be ignored.
- * OK: :root { --vs-document-root-counter-reset: foo bar; }
- * NG: :root { counter-reset: foo bar; }
+ *  Counter resetting/incrementing values
+ *  It is used for resetting/incrementing CSS counters on a root element or a first page
+ *  Caution: Don't set value directly otherwise all other counters will be ignored.
+ *  OK: :root { --vs-document-root-counter-reset: foo bar; }
+ *  NG: :root { counter-reset: foo bar; }
+ *
+ *  :root {
+ *    --vs-document-root-counter-reset: ;
+ *  }
+ *  @page :nth(1) {
+ *    --vs-document-first-page-counter-reset: ;
+ *  }
+ *  @page :first {
+ *    --vs-first-page-counter-reset: ;
+ *  }
+ *  @page :nth(1) {
+ *    --vs-document-first-page-counter-increment: ;
+ *  }
  */
-:root {
-  --vs-document-root-counter-reset: var(--vs-document-root-counter-reset,);
-}
-@page :nth(1) {
-  --vs-document-first-page-counter-reset: var(
-    --vs-document-first-page-counter-reset,
-  );
-}
-@page :first {
-  --vs-first-page-counter-reset: var(--vs-first-page-counter-reset,);
-}
-
-/**
- * Counter increments
- * It is used for incrementing CSS counters on a first page of a document
- * Caution: Don't set counter-reset directly otherwise all other counters will be ignored.
- * OK: :root { --vs-document-first-page-counter-increment: foo bar; }
- * NG: @page :nth(1) { counter-increment: foo bar; }
- */
-@page :nth(1) {
-  --vs-document-first-page-counter-increment: var(
-    --vs-document-first-page-counter-increment,
-  );
-}

--- a/packages/@vivliostyle/theme-base/css/common/meta-properties.css
+++ b/packages/@vivliostyle/theme-base/css/common/meta-properties.css
@@ -67,6 +67,7 @@
    * NG: :root { counter-reset: foo bar; }
    */
   --vs-document-root-counter-reset: ;
+  --vs-document-first-page-counter-reset: ;
   --vs-first-page-counter-reset: ;
 
   /**

--- a/packages/@vivliostyle/theme-base/css/common/meta-properties.css
+++ b/packages/@vivliostyle/theme-base/css/common/meta-properties.css
@@ -58,24 +58,36 @@
    */
   --vs-border-color: currentColor;
   --vs-border-width: 1px;
+}
 
-  /**
-   * Counter resets
-   * It is used for resetting CSS counters on a root element or a first page
-   * Caution: Don't set counter-reset directly otherwise all other counters will be ignored.
-   * OK: :root { --vs-document-root-counter-reset: foo bar; }
-   * NG: :root { counter-reset: foo bar; }
-   */
-  --vs-document-root-counter-reset: ;
-  --vs-document-first-page-counter-reset: ;
-  --vs-first-page-counter-reset: ;
+/**
+ * Counter resets
+ * It is used for resetting CSS counters on a root element or a first page
+ * Caution: Don't set counter-reset directly otherwise all other counters will be ignored.
+ * OK: :root { --vs-document-root-counter-reset: foo bar; }
+ * NG: :root { counter-reset: foo bar; }
+ */
+:root {
+  --vs-document-root-counter-reset: var(--vs-document-root-counter-reset,);
+}
+@page :nth(1) {
+  --vs-document-first-page-counter-reset: var(
+    --vs-document-first-page-counter-reset,
+  );
+}
+@page :first {
+  --vs-first-page-counter-reset: var(--vs-first-page-counter-reset,);
+}
 
-  /**
-   * Counter increments
-   * It is used for incrementing CSS counters on a first page of a document
-   * Caution: Don't set counter-reset directly otherwise all other counters will be ignored.
-   * OK: :root { --vs-document-first-page-counter-increment: foo bar; }
-   * NG: @page :nth(1) { counter-increment: foo bar; }
-   */
-  --vs-document-first-page-counter-increment: ;
+/**
+ * Counter increments
+ * It is used for incrementing CSS counters on a first page of a document
+ * Caution: Don't set counter-reset directly otherwise all other counters will be ignored.
+ * OK: :root { --vs-document-first-page-counter-increment: foo bar; }
+ * NG: @page :nth(1) { counter-increment: foo bar; }
+ */
+@page :nth(1) {
+  --vs-document-first-page-counter-increment: var(
+    --vs-document-first-page-counter-increment,
+  );
 }

--- a/packages/@vivliostyle/theme-base/css/partial/page.css
+++ b/packages/@vivliostyle/theme-base/css/partial/page.css
@@ -450,6 +450,7 @@ body:has([role='doc-cover']) {
 }
 
 @page :nth(1) {
+  counter-reset: var(--vs-document-first-page-counter-reset,);
   counter-increment: var(--vs-page--doc-counter-increment, vs-counter-doc)
     var(--vs-document-first-page-counter-increment,);
 }


### PR DESCRIPTION
Related: https://github.com/vivliostyle/vivliostyle-cli/issues/619 https://github.com/vivliostyle/vivliostyle-cli/pull/622

Add support for `--vs-document-first-page-counter-reset` variable to allow page counters and other counters to be reset on the first page of a document.