### PR TITLE
feat(theme-base): Change `@-adapt-footnote-area` to `@footnote`

### DIFF
--- a/.changeset/footnote-area-rule.md
+++ b/.changeset/footnote-area-rule.md
@@ -1,0 +1,5 @@
+---
+"@vivliostyle/theme-base": minor
+---
+
+Change `@-adapt-footnote-area` to `@footnote`

--- a/packages/@vivliostyle/theme-base/css/partial/footnote.css
+++ b/packages/@vivliostyle/theme-base/css/partial/footnote.css
@@ -76,20 +76,26 @@
   }
 }
 
-@-adapt-footnote-area {
-  margin-block: var(--vs-footnote--area-margin-block);
-}
+@page {
+  @footnote {
+    margin-block: var(--vs-footnote--area-margin-block);
+  }
 
-@-adapt-footnote-area ::before {
-  display: var(--vs-footnote--area-before-display);
-  border-block-start-color: var(
-    --vs-footnote--area-before-border-color,
-    var(--vs--hr-border-color, var(--vs-border-color))
-  );
-  border-block-start-width: var(
-    --vs-footnote--area-before-border-width,
-    var(--vs--hr-border-width, var(--vs-border-width))
-  );
-  margin-block: var(--vs-footnote--area-before-margin-block);
-  margin-inline: var(--vs-footnote--area-before-margin-inline);
+  @footnote ::before {
+    display: var(--vs-footnote--area-before-display);
+    border-block-start-style: var(
+      --vs-footnote--area-before-border-style,
+      solid
+    );
+    border-block-start-color: var(
+      --vs-footnote--area-before-border-color,
+      var(--vs--hr-border-color, var(--vs-border-color))
+    );
+    border-block-start-width: var(
+      --vs-footnote--area-before-border-width,
+      var(--vs--hr-border-width, var(--vs-border-width))
+    );
+    margin-block: var(--vs-footnote--area-before-margin-block);
+    margin-inline: var(--vs-footnote--area-before-margin-inline);
+  }
 }


### PR DESCRIPTION
Vivliostyle.js supports CSS GCPM `@footnote` rule since v2.41.0, and the old `@-adapt-footnote-area` rule is deprecated (see https://github.com/vivliostyle/vivliostyle.js/pull/1644). This commit changes `@-adapt-footnote-area` rules to `@footnote` rules in the base theme CSS.