### PR TITLE
docs: Add generative AI policy per NLnet guidelines

### DIFF
--- a/.agents/skills/ai-policy-check/SKILL.md
+++ b/.agents/skills/ai-policy-check/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: ai-policy-check
+description: Check compliance with AI_POLICY.md when creating a git commit or a pull request in this repository.
+---
+
+# AI Policy compliance check
+
+For commits and pull requests that contain AI-generated changes (see
+`AI_POLICY.md` at the repository root):
+
+- **Commit**: the message ends with `Assisted-by: AGENT_NAME:MODEL_VERSION`,
+  naming the exact model used, e.g. `Assisted-by: Claude Code:claude-fable-5`.
+  No `Co-authored-by:` trailer naming an AI.
+- **PR body**: contains the same `Assisted-by:` line, and a short description
+  of the human/AI division of labor inside a
+  `<details><summary>How the AI was used</summary>` block (see the example in
+  `AI_POLICY.md`).
+
+Fix anything that does not match before pushing or opening the PR.

--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!skills
+!skills/**

--- a/.claude/skills/ai-policy-check
+++ b/.claude/skills/ai-policy-check
@@ -1,0 +1,1 @@
+../../.agents/skills/ai-policy-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,11 @@
-CLAUDE.md
+# Agent guide
+
+This file provides guidance to AI coding agents (Claude Code, GitHub Copilot, Cursor, Codex, etc.) when working with code in this repository. It is the canonical source — `AGENTS.md` and `CLAUDE.md` point to the same content.
+
+## Generative AI policy
+
+This project follows the Vivliostyle organization's generative AI policy, disclosed in [`AI_POLICY.md`](AI_POLICY.md) per NLnet's guidelines. Agents must follow that policy:
+
+- Add an `Assisted-by:` trailer naming the agent and the exact model version to every commit that contains AI-generated changes, in the Linux-kernel format `Assisted-by: AGENT_NAME:MODEL_VERSION`, e.g. `Assisted-by: Claude Code:claude-fable-5`. Do not add a `Co-authored-by:` trailer for the AI.
+- When drafting a pull request description, include the same `Assisted-by:` line in the body, and describe the human/AI division of labor (what was delegated to the AI, and what the human contributor designed, decided, reviewed, and verified) inside a `<details>` block, following the example in `AI_POLICY.md`.
+- Never emit code that reproduces third-party copyrighted material.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,114 @@
+# Generative AI Policy
+
+This policy applies to the projects managed by the
+[Vivliostyle organization](https://github.com/vivliostyle). Several of these
+projects are developed with the support of NLnet Foundation grants and adhere
+to NLnet's
+[policy on the use of generative AI](https://nlnet.nl/foundation/policies/generativeAI/).
+This document is the public disclosure of our stance on generative AI use that
+the policy asks funded projects to provide.
+
+
+## Our stance
+
+We use generative AI tools in the development of our projects, and we disclose
+that use openly. AI is a tool that assists human developers. It does not
+replace human judgment or responsibility. A human maintainer designs, reviews,
+and verifies every change before it is merged. The human committer is fully
+responsible for the correctness, quality, and licensing of all submitted work,
+whether or not AI tools were used.
+
+## Tools we use
+
+- Claude Code (Anthropic): writing and refactoring code, writing tests,
+  debugging, documentation, and translation. The specific model is recorded
+  per commit (see below).
+- GitHub Copilot: code review suggestions and automated fixes (Copilot
+  Autofix).
+
+The set of tools varies by project and changes over time. The disclosure rules
+below apply to whichever generative AI tool is used. Some projects also use
+conventional machine translation (e.g. Google Cloud Translation) for
+localization. This is not generative AI, and humans review the translations
+before release.
+
+## Per-commit disclosure
+
+Commits that contain AI-generated code carry a trailer naming the tool and the
+specific model used. The preferred format is the `Assisted-by:` trailer
+[adopted by the Linux kernel](https://www.kernel.org/doc/html/latest/process/coding-assistants.html).
+It names the agent and the exact model version:
+
+```
+Assisted-by: Claude Code:claude-fable-5
+```
+
+We prefer this over `Co-authored-by:` because authorship, with the rights and
+responsibilities that come with it, stays with the human committer. The AI is
+a tool that assists. Trailers added automatically by tools, such as
+`Co-authored-by: Copilot <copilot@github.com>`, are also accepted as
+disclosure. Contributors do not need to reconfigure their tools.
+
+We do not put full prompt transcripts in commit messages. Instead, we describe
+the collaboration in the pull request: what was delegated to the AI, and what
+the human contributor designed, decided, reviewed, and verified. This shows
+the human design and review behind each change better than raw prompt logs
+would.
+
+The pull request body also carries the `Assisted-by:` line. Because the
+collaboration description tends to be long, wrap it in a `<details>` block so
+the body stays readable. For example:
+
+````markdown
+Fixes the print preview failing to load on Safari.
+
+Assisted-by: Claude Code:claude-fable-5
+
+<details>
+<summary>How the AI was used</summary>
+
+- The human author identified the bug from a user report, chose to fix it in
+  the service worker rather than the viewer, and required that the response
+  headers stay unchanged.
+- The AI located the failing code path, drafted the fix, and wrote a
+  regression test.
+- The human author reviewed the diff, simplified the error handling, and
+  verified the fix in Safari and Chrome before requesting review.
+
+</details>
+````
+
+## Human responsibility
+
+- A human maintainer reviews all AI-assisted changes before merge.
+- AI output is verified by building, type-checking, linting, and testing, and
+  by manual checks in the running software where relevant.
+- Polished-looking output is not a substitute for understanding. The committer
+  must be able to explain every change in review.
+
+## Copyright and licensing
+
+- Do not submit AI output that reproduces third-party copyrighted material.
+  Take extra care with output that is likely to resemble existing, well-known
+  code.
+- Purely AI-generated work with no meaningful human involvement is not
+  accepted.
+- All contributions must be publishable under a recognized free/open-source
+  license.
+
+## Contributions from others
+
+We welcome contributions, with or without AI assistance:
+
+- If you made substantive use of generative AI, say so in your pull request
+  description: which tool and model, and what you used it for. Add the trailer
+  described above to AI-assisted commits.
+- Write pull request descriptions and issue reports yourself. Clearly mark any
+  text written by an LLM.
+- You must understand the code you submit and be able to discuss it in review.
+
+## Review of this policy
+
+We review this policy whenever NLnet updates its generative AI policy, and as
+the generative AI landscape changes. Questions are welcome on the issue
+tracker of each project.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -8,7 +8,6 @@ to NLnet's
 This document is the public disclosure of our stance on generative AI use that
 the policy asks funded projects to provide.
 
-
 ## Our stance
 
 We use generative AI tools in the development of our projects, and we disclose
@@ -59,7 +58,7 @@ The pull request body also carries the `Assisted-by:` line. Because the
 collaboration description tends to be long, wrap it in a `<details>` block so
 the body stays readable. For example:
 
-````markdown
+```markdown
 Fixes the print preview failing to load on Safari.
 
 Assisted-by: Claude Code:claude-fable-5
@@ -76,7 +75,7 @@ Assisted-by: Claude Code:claude-fable-5
   verified the fix in Safari and Chrome before requesting review.
 
 </details>
-````
+```
 
 ## Human responsibility
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,1 @@
-# Agent guide
-
-This file provides guidance to AI coding agents (Claude Code, GitHub Copilot, Cursor, Codex, etc.) when working with code in this repository. It is the canonical source — `AGENTS.md` and `CLAUDE.md` point to the same content.
-
-## Generative AI policy
-
-This project follows the Vivliostyle organization's generative AI policy, disclosed in [`AI_POLICY.md`](AI_POLICY.md) per NLnet's guidelines. Agents must follow that policy:
-
-- Add an `Assisted-by:` trailer naming the agent and the exact model version to every commit that contains AI-generated changes, in the Linux-kernel format `Assisted-by: AGENT_NAME:MODEL_VERSION`, e.g. `Assisted-by: Claude Code:claude-fable-5`. Do not add a `Co-authored-by:` trailer for the AI.
-- When drafting a pull request description, include the same `Assisted-by:` line in the body, and describe the human/AI division of labor (what was delegated to the AI, and what the human contributor designed, decided, reviewed, and verified) inside a `<details>` block, following the example in `AI_POLICY.md`.
-- Never emit code that reproduces third-party copyrighted material.
+AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Agent guide
+
+This file provides guidance to AI coding agents (Claude Code, GitHub Copilot, Cursor, Codex, etc.) when working with code in this repository. It is the canonical source — `AGENTS.md` and `CLAUDE.md` point to the same content.
+
+## Generative AI policy
+
+This project follows the Vivliostyle organization's generative AI policy, disclosed in [`AI_POLICY.md`](AI_POLICY.md) per NLnet's guidelines. Agents must follow that policy:
+
+- Add an `Assisted-by:` trailer naming the agent and the exact model version to every commit that contains AI-generated changes, in the Linux-kernel format `Assisted-by: AGENT_NAME:MODEL_VERSION`, e.g. `Assisted-by: Claude Code:claude-fable-5`. Do not add a `Co-authored-by:` trailer for the AI.
+- When drafting a pull request description, include the same `Assisted-by:` line in the body, and describe the human/AI division of labor (what was delegated to the AI, and what the human contributor designed, decided, reviewed, and verified) inside a `<details>` block, following the example in `AI_POLICY.md`.
+- Never emit code that reproduces third-party copyrighted material.

--- a/README.md
+++ b/README.md
@@ -146,3 +146,7 @@ Create Vivliostyle theme at ease
 theme library and scripts
 
 <!-- END top -->
+
+## Credits
+
+This project uses generative AI tools in its development and discloses that use in [AI_POLICY.md](AI_POLICY.md), following NLnet's generative AI policy.


### PR DESCRIPTION
Adopts the organization-wide generative AI policy for this repository, as introduced for Vivliostyle Pub in vivliostyle/vivliostyle.pub#77, following NLnet's [generative AI policy](https://nlnet.nl/foundation/policies/generativeAI/).

- `AI_POLICY.md`: the same organization-wide policy document as vivliostyle.pub — our stance, the tools we use, per-commit and per-PR disclosure rules (kernel-style `Assisted-by:` trailer preferred over `Co-authored-by:`), human responsibility, and copyright rules.
- `README.md`: link to the policy from a new Credits section.
- `CLAUDE.md` / `AGENTS.md`: instructions for coding agents (trailer format, PR disclosure, no reproduction of copyrighted material). This repository previously had no agent guide, so the file is new, containing only the AI policy section.
- `.agents/skills/ai-policy-check`: a skill that checks compliance when committing or opening a PR (symlinked from `.claude/skills`).

Assisted-by: Claude Code:claude-fable-5

<details>
<summary>How the AI was used</summary>

- The human maintainer decided to adopt the policy from vivliostyle/vivliostyle.pub#77 in this repository, and reviews the result in this PR.
- The AI ported the policy document, README link, agent instructions, and the `ai-policy-check` skill from that PR, adapting them to this repository (new `CLAUDE.md`/`AGENTS.md`, new Credits section in `README.md`).

</details>